### PR TITLE
fix(parser): ignore xmlns namespace declarations on element attributes

### DIFF
--- a/src/Controller/ErnParserController.php
+++ b/src/Controller/ErnParserController.php
@@ -552,7 +552,14 @@ class ErnParserController {
       // then will call $this->ern->setMESSAGESCHEMAVERSIONID
       if (array_key_exists(count($this->pile), $this->attrs_to_process)) {
         foreach ($this->attrs_to_process[count($this->pile)] as $key => $val) {
-          if (in_array($key, $this->ignore_these_tags_or_attributes)) {
+          // Skip namespace declarations (xmlns, xmlns:*) regardless of the
+          // prefix used. They are never DDEX data, and replaying one as a child
+          // element fails: stripNamespacePrefix("xmlns:x") yields "x", which has
+          // no getter and throws "No functions found for this tag: x". The
+          // ignore list only covers a fixed set of prefixes (ern, ernm, xs...),
+          // so senders that pick another prefix (e.g. WMG's "x") broke parsing.
+          if ($key === "xmlns" || strpos($key, "xmlns:") === 0
+              || in_array($key, $this->ignore_these_tags_or_attributes)) {
             continue;
           }
 

--- a/src/Controller/ErnParserController.php
+++ b/src/Controller/ErnParserController.php
@@ -1679,7 +1679,9 @@ class ErnParserController {
       }
 
       // Try to find ERN-Main 32 namespace first (http://ddex.net/xml/2010/ern-main/32)
-      $re_ern_main = '/xmlns:ernm?="https?:\/\/ddex.net\/xml\/2010\/ern-main\/(\d+)"/m';
+      // Match any namespace-declaration prefix (xmlns, xmlns:ern, xmlns:x, ...);
+      // the version is identified by the ddex.net URL, not the chosen prefix.
+      $re_ern_main = '/xmlns(?::[\w-]+)?="https?:\/\/ddex.net\/xml\/2010\/ern-main\/(\d+)"/m';
       preg_match_all($re_ern_main, $trimed, $matches_ern_main, PREG_SET_ORDER, 0);
       
       if (!empty($matches_ern_main)) {
@@ -1687,8 +1689,11 @@ class ErnParserController {
         break;
       }
 
-      // Try to find version in this line (standard ERN pattern)
-      $re = '/xmlns:ernm?="https?:\/\/ddex.net\/xml\/ern\/(\d+)"/m';
+      // Try to find version in this line (standard ERN pattern). Match any
+      // namespace-declaration prefix (xmlns, xmlns:ern, xmlns:x, ...) so a
+      // sender that declares the ERN namespace solely under an arbitrary prefix
+      // is still detected. The ddex.net/xml/ern URL anchors the match.
+      $re = '/xmlns(?::[\w-]+)?="https?:\/\/ddex.net\/xml\/ern\/(\d+)"/m';
       preg_match_all($re, $trimed, $matches, PREG_SET_ORDER, 0);
 
       if (empty($matches)) {

--- a/src/Rule/AllSoundRecordingsHaveIsrc.php
+++ b/src/Rule/AllSoundRecordingsHaveIsrc.php
@@ -47,7 +47,7 @@ class AllSoundRecordingsHaveIsrc extends Rule {
       foreach ($sr->getSoundRecordingId() as $sri) {
         $isrc = $sri->getISRC();
         
-        if (empty(trim($isrc))) {
+        if (empty(trim($isrc ?? ''))) {
           return false;
         }
       }

--- a/tests/Controller/ParserControllerErrorsTest.php
+++ b/tests/Controller/ParserControllerErrorsTest.php
@@ -68,7 +68,8 @@ class ParserControllerErrorTest extends TestCase {
     try {
       $parser->parse("tests/samples/005_not_valid_xsd.xml");
     } catch (\Exception $ex) {
-      $expected_message = "No functions found for this tag: FakeTag. Path is NewReleaseMessage,ResourceList,SoundRecording";
+      // The parser appends " File: <path>" to fingerprint the offending file.
+      $expected_message = "No functions found for this tag: FakeTag. Path is NewReleaseMessage,ResourceList,SoundRecording File: tests/samples/005_not_valid_xsd.xml";
       $this->assertEquals($expected_message, $ex->getMessage());
     }
   }

--- a/tests/Controller/ParserControllerTest.php
+++ b/tests/Controller/ParserControllerTest.php
@@ -29,6 +29,31 @@ class ParserControllerTest extends TestCase {
     $this->assertEquals("MY_TAG", $parser_controller->cleanTag("MY:TAG"));
   }
 
+  /**
+   * Regression test: some senders (e.g. WMG) declare the ERN namespace with an
+   * arbitrary prefix such as "x" (xmlns:x) and use it on the root element. The
+   * namespace declaration must be ignored, not replayed as a child element.
+   * Before the fix this threw
+   * "No functions found for this tag: x. Path is NewReleaseMessage".
+   *
+   * tests/samples/020_xmlns_x_prefix.xml is sample 001 with the root namespace
+   * prefix changed from "ern" to "x".
+   */
+  public function testSample020XmlnsXPrefix() {
+    $xml_path = "tests/samples/020_xmlns_x_prefix.xml";
+    $parser_controller = new ErnParserController();
+    $parser_controller->setDisplayLog(false);
+    /* @var $ddex NewReleaseMessage */
+    $ddex = $parser_controller->parse($xml_path);
+
+    $this->assertInstanceOf(NewReleaseMessage::class, $ddex);
+    // Root attributes are still read despite the unusual namespace prefix
+    $this->assertEquals("ern/382", $ddex->getMessageSchemaVersionId());
+    $this->assertEquals("en", $ddex->getLanguageAndScriptCode());
+    // The full tree parsed, not just the root element
+    $this->assertCount(6, $ddex->getResourceList()->getSoundRecording());
+  }
+
   public function testSample001() {
     $xml_path = "tests/samples/001_audioalbum_complete.xml";
     $parser_controller = new ErnParserController();

--- a/tests/Controller/ParserControllerTest.php
+++ b/tests/Controller/ParserControllerTest.php
@@ -54,6 +54,29 @@ class ParserControllerTest extends TestCase {
     $this->assertCount(6, $ddex->getResourceList()->getSoundRecording());
   }
 
+  /**
+   * Regression test for the stronger case: the ERN namespace is declared
+   * *solely* under an arbitrary prefix (xmlns:x), with no xmlns:ern present.
+   * detectVersion() must recognize the version from the ddex.net URL regardless
+   * of prefix; otherwise it throws XmlLoadException("Could not find the
+   * xmlns:ern...") before parsing even begins.
+   *
+   * tests/samples/021_xmlns_x_only.xml is sample 001 with xmlns:ern renamed to
+   * xmlns:x (no recognized prefix left).
+   */
+  public function testSample021XmlnsXOnly() {
+    $xml_path = "tests/samples/021_xmlns_x_only.xml";
+    $parser_controller = new ErnParserController();
+    $parser_controller->setDisplayLog(false);
+    /* @var $ddex NewReleaseMessage */
+    $ddex = $parser_controller->parse($xml_path);
+
+    $this->assertInstanceOf(NewReleaseMessage::class, $ddex);
+    $this->assertEquals("ern/382", $ddex->getMessageSchemaVersionId());
+    $this->assertEquals("en", $ddex->getLanguageAndScriptCode());
+    $this->assertCount(6, $ddex->getResourceList()->getSoundRecording());
+  }
+
   public function testSample001() {
     $xml_path = "tests/samples/001_audioalbum_complete.xml";
     $parser_controller = new ErnParserController();

--- a/tests/Controller/ParserControllerTest.php
+++ b/tests/Controller/ParserControllerTest.php
@@ -325,7 +325,8 @@ class ParserControllerTest extends TestCase {
     $this->assertEquals("GBCVZ1900196", $sound_recording->getSoundRecordingId()[0]->getIsrc());
     $this->assertEquals("A58863644450088", $sound_recording->getResourceReference());
     $this->assertEquals("Bloodbuzz Ohio", $sound_recording->getReferenceTitle()->getTitleText());
-    $this->assertEquals("PT00H04M39S", $sound_recording->getDuration()->format("PT%iH%iM%sS"));
+    // %H/%I/%S are the zero-padded hour/minute/second codes (%i is minutes, not hours)
+    $this->assertEquals("PT00H04M39S", $sound_recording->getDuration()->format("PT%HH%IM%SS"));
 
     // SoundRecordingDetailsByTerritory
     $this->assertCount(1, $sound_recording->getSoundRecordingDetailsByTerritory());
@@ -349,14 +350,16 @@ class ParserControllerTest extends TestCase {
     $track_release = $ddex->getReleaseList()->getRelease()[0];
     $this->assertEquals("GBCVZ1900196", $track_release->getReleaseId()[0]->getIsrc());
     $this->assertEquals("R58863644450088", $track_release->getReleaseReference()[0]);
-    $this->assertEquals("TrackRelease", $track_release->getReleaseType());
+    // ERN32 ReleaseType is a repeatable element, so getReleaseType() is an array
+    $this->assertEquals("TrackRelease", $track_release->getReleaseType()[0]->value());
 
     // Second release (Single/Album)
     /* @var $album_release Ern32ReleaseType */
     $album_release = $ddex->getReleaseList()->getRelease()[1];
     $this->assertEquals("191402011555", $album_release->getReleaseId()[0]->getIcpn());
     $this->assertEquals("R58863643750032", $album_release->getReleaseReference()[0]);
-    $this->assertEquals("Single", $album_release->getReleaseType());
+    // ERN32 ReleaseType is a repeatable element, so getReleaseType() is an array
+    $this->assertEquals("Single", $album_release->getReleaseType()[0]->value());
     $this->assertEquals("Bloodbuzz Ohio", $album_release->getReferenceTitle()->getTitleText());
 
     // DealList
@@ -365,9 +368,11 @@ class ParserControllerTest extends TestCase {
     
     // Check first deal
     $deal = $ddex->getDealList()->getReleaseDeal()[0];
-    $this->assertEquals("R58863643750032", $deal->getDealReleaseReference());
-    $this->assertEquals("Download", $deal->getDeal()->getDealTerms()->getUsage()[0]->getUseType());
-    $this->assertGreaterThan(200, count($deal->getDeal()->getDealTerms()->getTerritoryCode())); // Worldwide territories
+    // ERN32 DealReleaseReference is repeatable, so getDealReleaseReference() is an array
+    $this->assertEquals("R58863643750032", $deal->getDealReleaseReference()[0]);
+    // ERN32 Deal / UseType are repeatable, so getDeal() and getUseType() are arrays
+    $this->assertEquals("Download", $deal->getDeal()[0]->getDealTerms()->getUsage()[0]->getUseType()[0]->value());
+    $this->assertGreaterThan(200, count($deal->getDeal()[0]->getDealTerms()->getTerritoryCode())); // Worldwide territories
   }
 
   /**
@@ -413,7 +418,8 @@ class ParserControllerTest extends TestCase {
     $album_release = $ddex->getReleaseList()->getRelease()[3];
     $this->assertEquals("191402800869", $album_release->getReleaseId()[0]->getIcpn());
     $this->assertEquals("The Wren, The Wren", $album_release->getReferenceTitle()->getTitleText());
-    $this->assertEquals("Album", $album_release->getReleaseType());
+    // ERN32 ReleaseType is a repeatable element, so getReleaseType() is an array
+    $this->assertEquals("Album", $album_release->getReleaseType()[0]->value());
     
     // Album should reference all 3 sound recordings + image
     $this->assertCount(4, $album_release->getReleaseResourceReferenceList());

--- a/tests/samples/018_ern411_nested_extent.xml
+++ b/tests/samples/018_ern411_nested_extent.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ern:NewReleaseMessage
+   xmlns:ern="http://ddex.net/xml/ern/411"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://ddex.net/xml/ern/411 release-notification.xsd"
+   ReleaseProfileVersionId="Audio" LanguageAndScriptCode="en">
+   <MessageHeader>
+      <MessageThreadId>Test1</MessageThreadId>
+      <MessageId>Test1.1</MessageId>
+      <MessageSender>
+         <PartyId>PADPIDA2013042401U</PartyId>
+         <PartyName>
+            <FullName>UniversalMusicGroup</FullName>
+         </PartyName>
+      </MessageSender>
+      <MessageRecipient>
+         <PartyId>PADPIDA2009101501Y</PartyId>
+         <PartyName>
+            <FullName>Sony DADC</FullName>
+         </PartyName>
+      </MessageRecipient>
+      <MessageCreatedDateTime>2013-11-26T14:30:00Z</MessageCreatedDateTime>
+   </MessageHeader>
+   <ResourceList>
+      <Image>
+         <ResourceReference>IMG1</ResourceReference>
+         <Type>FrontCoverImage</Type>
+         <ResourceId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">PACKSHOT:0094631432057</ProprietaryId>
+         </ResourceId>
+         <ParentalWarningType>NotExplicit</ParentalWarningType>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T1</TechnicalResourceDetailsReference>
+            <!-- Malformed-but-seen-in-the-wild nesting: <Extent> wrapped inside
+                 ImageHeight/ImageWidth instead of the value sitting directly on
+                 the ExtentType element. UnitOfMeasure rides on the Extent. -->
+            <ImageHeight><Extent>300</Extent></ImageHeight>
+            <ImageWidth><Extent UnitOfMeasure="Pixel">300</Extent></ImageWidth>
+            <File>
+               <URI>0094631432057.jpg</URI>
+            </File>
+         </TechnicalDetails>
+      </Image>
+   </ResourceList>
+</ern:NewReleaseMessage>

--- a/tests/samples/020_xmlns_x_prefix.xml
+++ b/tests/samples/020_xmlns_x_prefix.xml
@@ -1,0 +1,864 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+	(c) Digital Data Exchange, LLC (DDEX)
+	This file forms part of the DDEX Standard defining Release Profiles for Common Release Types (Version 1.4)	
+-->
+<x:NewReleaseMessage xmlns:ern="http://ddex.net/xml/ern/382"
+	xmlns:x="http://ddex.net/xml/ern/382"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+	xs:schemaLocation="http://ddex.net/xml/ern/382 http://ddex.net/xml/ern/382/release-notification.xsd"
+	MessageSchemaVersionId="ern/382"
+	ReleaseProfileVersionId="CommonReleaseTypesTypes/14/AudioAlbumMusicOnly"
+	LanguageAndScriptCode="en">
+
+	<MessageHeader>
+		<MessageThreadId/>
+		<MessageId/>
+		<MessageSender>
+			<PartyId>DPID_OF_THE_SENDER</PartyId>
+		</MessageSender>
+		<MessageRecipient>
+			<PartyId>DPID_OF_THE_RECIPIENT</PartyId>
+		</MessageRecipient>
+		<MessageCreatedDateTime>2012-12-11T15:50:00+00:00</MessageCreatedDateTime>
+	</MessageHeader>
+
+	<!-- The IsBackfill flag is optional and should only be used for indicating that an XML file is part of
+		a special backfill of a (typically large) catalogue -->
+	<IsBackfill>true</IsBackfill>
+
+	<ResourceList>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000001</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A1</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+			</ReferenceTitle>
+			<Duration>PT13M31S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Can you feel ...the Monkey Claw! formal</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<DisplayArtist SequenceNumber="2">
+					<PartyName>
+						<FullName>Second Artist</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T1</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_01.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000002</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A2</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Red top mountain, blown sky high</TitleText>
+			</ReferenceTitle>
+			<Duration>PT6M6S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Red top mountain, blown sky high</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Red top mountain, blown sky high</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T2</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_02.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000003</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A3</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Seige of Antioch</TitleText>
+			</ReferenceTitle>
+			<Duration>PT21M9S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Seige of Antioch</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Seige of Antioch</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T3</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_03.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000004</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A4</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Warhammer</TitleText>
+			</ReferenceTitle>
+			<Duration>PT2M45S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Warhammer</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Warhammer</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T4</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_04.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000005</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A5</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Iron Horse</TitleText>
+			</ReferenceTitle>
+			<Duration>PT4M54S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Iron Horse</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Iron Horse</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T5</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_05.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000006</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A6</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+			</ReferenceTitle>
+			<Duration>PT12M21S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T6</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_06.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<Image>
+			<ImageType>FrontCoverImage</ImageType>
+			<ImageId>
+				<ProprietaryId Namespace="DPID:PADPIDA0000000001A">PId0401</ProprietaryId>
+			</ImageId>
+			<ResourceReference>A7</ResourceReference>
+			<ImageDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalImageDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalImageDetails>
+					<TechnicalResourceDetailsReference>T7</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X.jpeg</FileName>
+					</File>
+				</TechnicalImageDetails>
+			</ImageDetailsByTerritory>
+		</Image>
+	</ResourceList>
+
+	<ReleaseList>
+		<Release IsMainRelease="true">
+			<ReleaseId>
+				<GRid>A1UCASE0000000401X</GRid>
+			</ReleaseId>
+			<ReleaseReference>R0</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>A Monkey Claw in a Velvet Glove</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A1</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A2</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A3</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A4</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A5</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A6</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="SecondaryResource"
+					>A7</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>Album</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>A Monkey Claw in a Velvet Glove formal</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>A Monkey Claw in a Velvet Glove</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroup>
+						<Title TitleType="GroupingTitle">
+							<TitleText>Component 1</TitleText>
+						</Title>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceGroupContentItem>
+							<SequenceNumber>1</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A1</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>2</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A2</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>3</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A3</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>4</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A4</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>5</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A5</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>6</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A6</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+					</ResourceGroup>
+					<ResourceGroupContentItem>
+						<ResourceType>Image</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="SecondaryResource"
+							>A7</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000001X</GRid>
+				<ISRC>CASE00000001</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R1</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A1</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A1</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000002X</GRid>
+				<ISRC>CASE00000002</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R2</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Red top mountain, blown sky high</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A2</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Red top mountain, blown sky high</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Red top mountain, blown sky high</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A2</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000003X</GRid>
+				<ISRC>CASE00000003</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R3</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Seige of Antioch</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A3</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Seige of Antioch</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Seige of Antioch</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A3</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000004X</GRid>
+				<ISRC>CASE00000004</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R4</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Warhammer</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A4</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Warhammer</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Warhammer</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A4</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000005X</GRid>
+				<ISRC>CASE00000005</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R5</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Iron Horse</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A5</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Iron Horse</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Iron Horse</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A5</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000006X</GRid>
+				<ISRC>CASE00000006</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R6</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A6</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A6</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+	</ReleaseList>
+</x:NewReleaseMessage>

--- a/tests/samples/021_xmlns_x_only.xml
+++ b/tests/samples/021_xmlns_x_only.xml
@@ -1,0 +1,863 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+	(c) Digital Data Exchange, LLC (DDEX)
+	This file forms part of the DDEX Standard defining Release Profiles for Common Release Types (Version 1.4)	
+-->
+<x:NewReleaseMessage xmlns:x="http://ddex.net/xml/ern/382"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+	xs:schemaLocation="http://ddex.net/xml/ern/382 http://ddex.net/xml/ern/382/release-notification.xsd"
+	MessageSchemaVersionId="ern/382"
+	ReleaseProfileVersionId="CommonReleaseTypesTypes/14/AudioAlbumMusicOnly"
+	LanguageAndScriptCode="en">
+
+	<MessageHeader>
+		<MessageThreadId/>
+		<MessageId/>
+		<MessageSender>
+			<PartyId>DPID_OF_THE_SENDER</PartyId>
+		</MessageSender>
+		<MessageRecipient>
+			<PartyId>DPID_OF_THE_RECIPIENT</PartyId>
+		</MessageRecipient>
+		<MessageCreatedDateTime>2012-12-11T15:50:00+00:00</MessageCreatedDateTime>
+	</MessageHeader>
+
+	<!-- The IsBackfill flag is optional and should only be used for indicating that an XML file is part of
+		a special backfill of a (typically large) catalogue -->
+	<IsBackfill>true</IsBackfill>
+
+	<ResourceList>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000001</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A1</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+			</ReferenceTitle>
+			<Duration>PT13M31S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Can you feel ...the Monkey Claw! formal</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<DisplayArtist SequenceNumber="2">
+					<PartyName>
+						<FullName>Second Artist</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T1</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_01.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000002</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A2</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Red top mountain, blown sky high</TitleText>
+			</ReferenceTitle>
+			<Duration>PT6M6S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Red top mountain, blown sky high</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Red top mountain, blown sky high</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T2</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_02.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000003</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A3</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Seige of Antioch</TitleText>
+			</ReferenceTitle>
+			<Duration>PT21M9S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Seige of Antioch</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Seige of Antioch</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T3</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_03.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000004</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A4</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Warhammer</TitleText>
+			</ReferenceTitle>
+			<Duration>PT2M45S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Warhammer</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Warhammer</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T4</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_04.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000005</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A5</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Iron Horse</TitleText>
+			</ReferenceTitle>
+			<Duration>PT4M54S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Iron Horse</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Iron Horse</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T5</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_05.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<SoundRecording>
+			<SoundRecordingType>MusicalWorkSoundRecording</SoundRecordingType>
+			<SoundRecordingId>
+				<ISRC>CASE00000006</ISRC>
+			</SoundRecordingId>
+			<IndirectSoundRecordingId>
+				<ISWC>T1234567890</ISWC>
+			</IndirectSoundRecordingId>
+			<ResourceReference>A6</ResourceReference>
+			<ReferenceTitle>
+				<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+			</ReferenceTitle>
+			<Duration>PT12M21S</Duration>
+			<SoundRecordingDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<Title TitleType="FormalTitle">
+					<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Steve Albino</FullName>
+					</PartyName>
+					<ResourceContributorRole>Producer</ResourceContributorRole>
+				</ResourceContributor>
+
+				<!-- No DisplayArtistName is shown here as the DisplayArtistName is the same as for the Release -->
+
+				<IndirectResourceContributor SequenceNumber="1">
+					<PartyName>
+						<FullName>Bob Black</FullName>
+					</PartyName>
+					<IndirectResourceContributorRole>Composer</IndirectResourceContributorRole>
+				</IndirectResourceContributor>
+				<ResourceReleaseDate>2011</ResourceReleaseDate>
+				<PLine>
+					<Year>2010</Year>
+					<PLineText>(P) 2010 Iron Crown Music</PLineText>
+				</PLine>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalSoundRecordingDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalSoundRecordingDetails>
+					<TechnicalResourceDetailsReference>T6</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X_01_06.wav</FileName>
+					</File>
+				</TechnicalSoundRecordingDetails>
+			</SoundRecordingDetailsByTerritory>
+		</SoundRecording>
+		<Image>
+			<ImageType>FrontCoverImage</ImageType>
+			<ImageId>
+				<ProprietaryId Namespace="DPID:PADPIDA0000000001A">PId0401</ProprietaryId>
+			</ImageId>
+			<ResourceReference>A7</ResourceReference>
+			<ImageDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<!-- TechnicalImageDetails are only to be provided when relevant Resource Files are communicated -->
+				<TechnicalImageDetails>
+					<TechnicalResourceDetailsReference>T7</TechnicalResourceDetailsReference>
+					<File>
+						<FileName>A1UCASE0000000401X.jpeg</FileName>
+					</File>
+				</TechnicalImageDetails>
+			</ImageDetailsByTerritory>
+		</Image>
+	</ResourceList>
+
+	<ReleaseList>
+		<Release IsMainRelease="true">
+			<ReleaseId>
+				<GRid>A1UCASE0000000401X</GRid>
+			</ReleaseId>
+			<ReleaseReference>R0</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>A Monkey Claw in a Velvet Glove</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A1</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A2</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A3</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A4</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A5</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A6</ReleaseResourceReference>
+				<ReleaseResourceReference ReleaseResourceType="SecondaryResource"
+					>A7</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>Album</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>A Monkey Claw in a Velvet Glove formal</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>A Monkey Claw in a Velvet Glove</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroup>
+						<Title TitleType="GroupingTitle">
+							<TitleText>Component 1</TitleText>
+						</Title>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceGroupContentItem>
+							<SequenceNumber>1</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A1</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>2</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A2</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>3</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A3</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>4</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A4</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>5</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A5</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+						<ResourceGroupContentItem>
+							<SequenceNumber>6</SequenceNumber>
+							<ResourceType>SoundRecording</ResourceType>
+							<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+								>A6</ReleaseResourceReference>
+						</ResourceGroupContentItem>
+					</ResourceGroup>
+					<ResourceGroupContentItem>
+						<ResourceType>Image</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="SecondaryResource"
+							>A7</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000001X</GRid>
+				<ISRC>CASE00000001</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R1</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A1</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Can you feel ...the Monkey Claw!</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A1</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000002X</GRid>
+				<ISRC>CASE00000002</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R2</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Red top mountain, blown sky high</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A2</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Red top mountain, blown sky high</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Red top mountain, blown sky high</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A2</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000003X</GRid>
+				<ISRC>CASE00000003</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R3</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Seige of Antioch</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A3</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Seige of Antioch</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Seige of Antioch</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A3</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000004X</GRid>
+				<ISRC>CASE00000004</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R4</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Warhammer</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A4</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Warhammer</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Warhammer</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A4</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000005X</GRid>
+				<ISRC>CASE00000005</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R5</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Iron Horse</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A5</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Iron Horse</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Iron Horse</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A5</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+		<Release>
+			<ReleaseId>
+				<GRid>A1UCASE0000000006X</GRid>
+				<ISRC>CASE00000006</ISRC>
+			</ReleaseId>
+			<ReleaseReference>R6</ReleaseReference>
+			<ReferenceTitle>
+				<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+			</ReferenceTitle>
+			<ReleaseResourceReferenceList>
+				<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+					>A6</ReleaseResourceReference>
+			</ReleaseResourceReferenceList>
+			<ReleaseType>TrackRelease</ReleaseType>
+			<ReleaseDetailsByTerritory>
+				<TerritoryCode>Worldwide</TerritoryCode>
+				<DisplayArtistName>Monkey Claw</DisplayArtistName>
+				<LabelName>Iron Crown Music</LabelName>
+				<Title TitleType="FormalTitle">
+					<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+				</Title>
+				<Title TitleType="DisplayTitle">
+					<TitleText>Yes... I can feel the Monkey Claw!</TitleText>
+				</Title>
+				<DisplayArtist SequenceNumber="1">
+					<PartyName>
+						<FullName>Monkey Claw</FullName>
+					</PartyName>
+					<ArtistRole>MainArtist</ArtistRole>
+				</DisplayArtist>
+				<ParentalWarningType>NotExplicit</ParentalWarningType>
+				<ResourceGroup>
+					<ResourceGroupContentItem>
+						<SequenceNumber>1</SequenceNumber>
+						<ResourceType>SoundRecording</ResourceType>
+						<ReleaseResourceReference ReleaseResourceType="PrimaryResource"
+							>A6</ReleaseResourceReference>
+					</ResourceGroupContentItem>
+				</ResourceGroup>
+				<Genre>
+					<GenreText>Metal</GenreText>
+					<SubGenre>Progressive Metal</SubGenre>
+				</Genre>
+				<ReleaseDate IsApproximate="true">2010-01-01</ReleaseDate>
+			</ReleaseDetailsByTerritory>
+			<PLine>
+				<Year>2010</Year>
+				<PLineText>(P) 2010 Iron Crown Music</PLineText>
+			</PLine>
+			<CLine>
+				<Year>2010</Year>
+				<CLineText>(C) 2010 Iron Crown Music</CLineText>
+			</CLine>
+			<GlobalOriginalReleaseDate IsApproximate="true">2010-10-01</GlobalOriginalReleaseDate>
+		</Release>
+	</ReleaseList>
+</x:NewReleaseMessage>


### PR DESCRIPTION
## Problem

The DDEX parser crashes on `NewReleaseMessage` files that declare the ERN namespace with an arbitrary prefix and use it on the root element. Warner Music Group sends files like:

```xml
<x:NewReleaseMessage xmlns:ernm="http://ddex.net/xml/ern/341"
                     xmlns:x="http://ddex.net/xml/ern/341" ...>
```

When an element closes, `callbackEndElement` replays each of its attributes as a pseudo child element (so attributes like `MessageSchemaVersionId` become setters). The guard that skips non-data attributes is a hardcoded allowlist (`ignore_these_tags_or_attributes`): `xmlns:ern`, `xmlns:ernm`, `xmlns:xs`, etc. — but **not** `xmlns:x`.

So `xmlns:x` was replayed as a child element, `stripNamespacePrefix("xmlns:x")` reduced it to `x`, no `getX()` getter exists on `NewReleaseMessage`, and the parser threw:

```
Exception: No functions found for this tag: x. Path is NewReleaseMessage
```

## Sentry

Solves **[TABASCO-1MQ](https://sauce-industries-170376728.sentry.io/issues/TABASCO-1MQ)** (sauce-industries / tabasco) — ~200 occurrences, escalating, across WMG `new_release` files in production.

## Fix

1. **Attribute-replay path** — skip **any** `xmlns` / `xmlns:*` attribute generically instead of relying on the allowlist of known prefixes. Namespace declarations are never DDEX data, so no sender's choice of prefix can break parsing anymore.
2. **`detectVersion()`** — widened both regexes to recognize the ERN namespace under any prefix (`xmlns(?::[\w-]+)?="...ddex.net/xml/ern/(\d+)"`), anchored on the DDEX URL. Without this, a file declaring the namespace *solely* under an arbitrary prefix (only `xmlns:x`, no `xmlns:ern`) would throw `XmlLoadException("Could not find the xmlns:ern...")` before parsing began. (Per review feedback.)

PHP 7.2-compatible (`strpos(...) === 0`, not `str_starts_with`), in line with `composer.json` (`php: ^7.2|^8.0`).

## Tests

New regression coverage for the namespace handling:
- `tests/samples/020_xmlns_x_prefix.xml` + `testSample020XmlnsXPrefix` — root prefixed `x:` alongside a recognized `xmlns:ern` (the WMG shape).
- `tests/samples/021_xmlns_x_only.xml` + `testSample021XmlnsXOnly` — ERN namespace declared **solely** under `xmlns:x`, exercising the `detectVersion` path.

Both fail before the fix (with the exact production exception / `XmlLoadException`) and pass after.

## Also fixed (pre-existing, unrelated to the namespace bug)

The suite was already red on `master` from earlier ERN32 / Extent WIP and the exception file-fingerprinting change. Cleaned up here so CI is green end-to-end:

| Test / item | Root cause | Fix |
| --- | --- | --- |
| `testSample018Ern411NestedExtent` | Fixture `018_ern411_nested_extent.xml` was never committed (test added without its sample) | Authored a minimal ERN411 fixture with the malformed nested-`Extent` pattern |
| `testSample018Ern32` | Duration format string used `%i` (minutes) in the hours slot | Switched to `%H/%I/%S` → `PT00H04M39S` |
| `testSample018Ern32` / `testSample019Ern32Ep` | ERN32 `ReleaseType` / `Deal` / `DealReleaseReference` / `UseType` are repeatable elements (arrays), asserted as scalars | Index `[0]` and call `->value()` on the `*Type` wrappers |
| `testNotValidXsd` | Parser now appends ` File: <path>` to the exception message | Updated the expected message |
| `AllSoundRecordingsHaveIsrc` | `getISRC()` can be null; `trim(null)` is deprecated on PHP 8.1+ (emitted a notice during the run) | `trim($isrc ?? '')` |

Full suite after this PR: **OK (29 tests, 263 assertions)**, no deprecation notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)